### PR TITLE
Try to obtain last_id from the list of notifications

### DIFF
--- a/cz_nia/message.py
+++ b/cz_nia/message.py
@@ -244,7 +244,7 @@ class NotificationMessage(NiaMessage):
         if last_id_node is not None:
             last_id = int(last_id_node.text)  # type: Optional[int]
         else:
-            last_id = None
+            last_id = max((int(notif['id']) for notif in notification_list), default=None)
         more_notifications_node = response.find('nia:ExistujiDalsiNotifikace', namespaces=self.get_namespace_map)
         if more_notifications_node is not None:
             more_notifications = more_notifications_node.text.lower() == 'true'

--- a/cz_nia/tests/test_functions.py
+++ b/cz_nia/tests/test_functions.py
@@ -202,7 +202,7 @@ class TestGetNotification(TestCase):
                      body=file_content('notifications.xml'))
             notifications = get_notification(SETTINGS)
         self.assertFalse(notifications.more_notifications)
-        self.assertIsNone(notifications.last_id)
+        self.assertEqual(notifications.last_id, 11701)
         self.assertEqual(len(notifications.notifications), 12)
         self.assertEqual(notifications.notifications[0],
                          {'source': 'ROBREF',

--- a/cz_nia/tests/test_message.py
+++ b/cz_nia/tests/test_message.py
@@ -309,6 +309,31 @@ class TestNotificationMessage(TestCase):
         self.assertEqual(response.last_id, 133)
         self.assertTrue(response.more_notifications)
 
+    def test_parse_success_no_last_id(self):
+        content = '<NotifikaceIdpResponse xmlns="urn:nia.notifikaceIdp/response:v1" \
+                   xmlns:xsd="http://www.w3.org/2001/XMLSchema" \
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"> \
+                   <Status>OK</Status> \
+                   <SeznamNotifikaceIdp> \
+                   <NotifikaceIdp> \
+                   <NotifikaceIdpId>132</NotifikaceIdpId> \
+                   <Bsi>some_pseudonym</Bsi> \
+                   <DatumACasNotifikace>2017-12-07T14:41:01.787</DatumACasNotifikace> \
+                   <Zdroj>ROBREF</Zdroj> \
+                   <Text>Zmena referencních údaju ROB.</Text> \
+                   </NotifikaceIdp> \
+                   </SeznamNotifikaceIdp> \
+                   <ExistujiDalsiNotifikace>true</ExistujiDalsiNotifikace> \
+                   </NotifikaceIdpResponse>'
+        response = fromstring(BASE_BODY.format(CONTENT=content).encode())
+        body = response.find('gov:Body/nia:NotifikaceIdpResponse', namespaces=NotificationMessage('').get_namespace_map)
+        response = NotificationMessage(None).extract_message(body)
+        self.assertEqual(response.notifications, [{'id': '132', 'pseudonym': 'some_pseudonym', 'source': 'ROBREF',
+                                                   'message': 'Zmena referencních údaju ROB.',
+                                                   'datetime': datetime.datetime(2017, 12, 7, 14, 41, 1, 787000)}])
+        self.assertEqual(response.last_id, 132)
+        self.assertTrue(response.more_notifications)
+
     def test_parse_success_no_micro(self):
         content = '<NotifikaceIdpResponse xmlns="urn:nia.notifikaceIdp/response:v1" \
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema" \


### PR DESCRIPTION
The `last_id` node is not necessarily included on all messages. Knowing the `last_id` is important to properly restart the download of notifications.

Try to guess it from the list of notifications.